### PR TITLE
Remove chai-as-promised from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "test": "gulp lint && gulp test"
   },
   "dependencies": {
-    "chai-as-promised": "^4.1.1",
     "underscore": "^1.7.0"
   },
   "devDependencies": {
+    "chai-as-promised": "^4.1.1",
     "chai": "^1.9.1",
     "del": "^0.1.3",
     "gulp": "^3.8.7",


### PR DESCRIPTION
We should not be including chai-as-promised as a core dependancy.

This limits the size of the package when installed and speeds up install time for others.
